### PR TITLE
fix: adapt org.reflections API usage for 0.10.2

### DIFF
--- a/src/main/groovy/com/fizzpod/gradle/plugins/pater/ClasspathGradleBuildFileResolver.groovy
+++ b/src/main/groovy/com/fizzpod/gradle/plugins/pater/ClasspathGradleBuildFileResolver.groovy
@@ -1,4 +1,4 @@
-/* (C) 2025 */
+/* (C) 2025-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.pater
 

--- a/src/main/groovy/com/fizzpod/gradle/plugins/pater/ClasspathGradleBuildFileResolver.groovy
+++ b/src/main/groovy/com/fizzpod/gradle/plugins/pater/ClasspathGradleBuildFileResolver.groovy
@@ -12,7 +12,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.reflections.Reflections
-import org.reflections.scanners.ResourcesScanner
+import org.reflections.scanners.Scanners
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -46,10 +46,10 @@ public class ClasspathGradleBuildFileResolver implements GradleBuildFileResolver
 
     private Set<String> scanForBuildFiles() {
 
-        Reflections reflections = new Reflections("META-INF.pater-build", new ResourcesScanner())
+        Reflections reflections = new Reflections("META-INF.pater-build", Scanners.Resources)
 
         Set<String> buildFiles =
-                reflections.getResources(Pattern.compile(".*\\.gradle"))
+                reflections.getResources(".*\\.gradle")
         return buildFiles
     }
 

--- a/src/main/groovy/com/fizzpod/gradle/plugins/pater/FileNameGradleBuildFileSorter.groovy
+++ b/src/main/groovy/com/fizzpod/gradle/plugins/pater/FileNameGradleBuildFileSorter.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.pater
 

--- a/src/main/groovy/com/fizzpod/gradle/plugins/pater/FileNameGradleBuildFileSorter.groovy
+++ b/src/main/groovy/com/fizzpod/gradle/plugins/pater/FileNameGradleBuildFileSorter.groovy
@@ -8,8 +8,6 @@ import java.util.regex.Pattern
 import org.apache.commons.io.FilenameUtils
 import org.apache.commons.io.IOUtils
 import org.gradle.api.Project
-import org.reflections.Reflections
-import org.reflections.scanners.ResourcesScanner
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 


### PR DESCRIPTION
Fixes compilation failure after Dependabot updated org.reflections:reflections from 0.9.12 to 0.10.2.

- Replaced deprecated/removed `ResourcesScanner()` with `Scanners.Resources`.
- Updated `getResources()` call to accept a String regex rather than a `Pattern` object, as per the 0.10.2 API changes.
- Removed unused imports.

---
*PR created automatically by Jules for task [14644554273466952623](https://jules.google.com/task/14644554273466952623) started by @boxheed*